### PR TITLE
PYMT-569: Exception handler now translates the message by itself.

### DIFF
--- a/src/Exceptions/ExceptionHandler.php
+++ b/src/Exceptions/ExceptionHandler.php
@@ -189,9 +189,22 @@ abstract class ExceptionHandler extends Handler
      */
     private function getExceptionMessage(Throwable $exception, string $default): string
     {
-        return $this->inProduction() === false && empty($exception->getMessage()) === false ?
-            $exception->getMessage() :
-            $default;
+        if ($this->inProduction() === true || $exception->getMessage() === '') {
+            return $default;
+        }
+
+        $params = [];
+
+        if (($exception instanceof ExceptionInterface) === true) {
+            /**
+             * @var \EoneoPay\Utils\Interfaces\Exceptions\ExceptionInterface $exception
+             *
+             * @see https://youtrack.jetbrains.com/issue/WI-37859 - typehint required until PhpStorm recognises ===
+             */
+            $params = $exception->getMessageParameters();
+        }
+
+        return $this->translator->trans($exception->getMessage(), $params);
     }
 
     /**
@@ -263,7 +276,7 @@ abstract class ExceptionHandler extends Handler
      */
     private function isJson(string $string): bool
     {
-        \json_decode($string);
+        \json_decode($string, true);
 
         return \json_last_error() === \JSON_ERROR_NONE;
     }

--- a/tests/Exceptions/Stubs/ClientExceptionStub.php
+++ b/tests/Exceptions/Stubs/ClientExceptionStub.php
@@ -32,7 +32,7 @@ class ClientExceptionStub extends Exception implements ClientExceptionInterface
     }
 
     /**
-     * {{@inheritdoc}}
+     * {@inheritdoc}
      */
     public function getMessageParameters(): array
     {


### PR DESCRIPTION
Exception handler now translates the message by itself. So if exception has a translatable key instead of message itself, Exception handler takes care of it.

[Link to card](https://loyaltycorp.atlassian.net/secure/RapidBoard.jspa?rapidView=36&projectKey=PYMT&modal=detail&selectedIssue=PYMT-569&assignee=rashmit)

The base idea here is to be able to get rid of Translator for exceptions. 