### PR TITLE
PYMT-937 Bump externals, make adjustments because of EntityInterface

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1055,16 +1055,16 @@
         },
         {
             "name": "eoneopay/externals",
-            "version": "v1.0.0-RC14",
+            "version": "v1.0.0-RC16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loyaltycorp/externals.git",
-                "reference": "7f4f9b9ad50ee692f8f6972bcfe19c6135cf4797"
+                "reference": "2db2b4b7ce40570dccbd1cbdfae71d66455779e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loyaltycorp/externals/zipball/7f4f9b9ad50ee692f8f6972bcfe19c6135cf4797",
-                "reference": "7f4f9b9ad50ee692f8f6972bcfe19c6135cf4797",
+                "url": "https://api.github.com/repos/loyaltycorp/externals/zipball/2db2b4b7ce40570dccbd1cbdfae71d66455779e8",
+                "reference": "2db2b4b7ce40570dccbd1cbdfae71d66455779e8",
                 "shasum": ""
             },
             "require": {
@@ -1092,6 +1092,7 @@
                 "mikey179/vfsstream": "^1.6",
                 "monolog/monolog": "^1.23",
                 "nicoswd/php-gpg": "^1.7",
+                "paragonie/hidden-string": "^1.0",
                 "phpmd/phpmd": "^2.6",
                 "phpstan/phpstan": "^0.11",
                 "phpstan/phpstan-phpunit": "^0.11.0",
@@ -1133,7 +1134,7 @@
             "keywords": [
                 "external"
             ],
-            "time": "2019-07-03T03:19:27+00:00"
+            "time": "2019-08-20T02:39:01+00:00"
         },
         {
             "name": "eoneopay/utils",
@@ -3869,7 +3870,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -5213,7 +5214,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🔍 Nette Finder: find files and directories with an intuitive API.",
+            "description": "? Nette Finder: find files and directories with an intuitive API.",
             "homepage": "https://nette.org",
             "keywords": [
                 "filesystem",
@@ -5273,7 +5274,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🍸 Nette NEON: encodes and decodes NEON file format.",
+            "description": "? Nette NEON: encodes and decodes NEON file format.",
             "homepage": "http://ne-on.org",
             "keywords": [
                 "export",

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -7,6 +7,7 @@ use EoneoPay\ApiFormats\Bridge\Laravel\Responses\FormattedApiResponse;
 use EoneoPay\ApiFormats\Interfaces\FormattedApiResponseInterface;
 use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
 use EoneoPay\Externals\ORM\Interfaces\EntityManagerInterface;
+use EoneoPay\Externals\ORM\Interfaces\MagicEntityInterface;
 use EoneoPay\Externals\Request\Interfaces\RequestInterface;
 use EoneoPay\Framework\Exceptions\EntityNotFoundException;
 use EoneoPay\Framework\Interfaces\ControllerInterface;
@@ -45,7 +46,7 @@ abstract class Controller extends BaseController implements ControllerInterface
         string $entityClass,
         RequestInterface $request
     ): FormattedApiResponseInterface {
-        /** @var \EoneoPay\Externals\ORM\Interfaces\EntityInterface $entity */
+        /** @var \EoneoPay\Externals\ORM\Interfaces\MagicEntityInterface $entity */
         $entity = new $entityClass($request->toArray());
 
         $this->saveEntity($entity);
@@ -117,7 +118,7 @@ abstract class Controller extends BaseController implements ControllerInterface
      * @param string $entityId
      * @param null|string $notFoundException
      *
-     * @return \EoneoPay\Externals\ORM\Interfaces\EntityInterface
+     * @return \EoneoPay\Externals\ORM\Interfaces\MagicEntityInterface
      *
      * @throws \EoneoPay\Utils\Exceptions\NotFoundException
      */
@@ -125,17 +126,17 @@ abstract class Controller extends BaseController implements ControllerInterface
         string $entityClass,
         string $entityId,
         ?string $notFoundException = null
-    ): EntityInterface {
+    ): MagicEntityInterface {
         $entity = $this->getEntityManager()->getRepository($entityClass)->find($entityId);
 
-        if (($entity instanceof EntityInterface) === false) {
+        if (($entity instanceof MagicEntityInterface) === false) {
             $exceptionClass = $notFoundException ?? EntityNotFoundException::class;
 
             throw new $exceptionClass(\sprintf('%s %s not found', $entityClass, $entityId));
         }
 
         /**
-         * @var \EoneoPay\Externals\ORM\Interfaces\EntityInterface $entity
+         * @var \EoneoPay\Externals\ORM\Interfaces\MagicEntityInterface $entity
          *
          * @see https://youtrack.jetbrains.com/issue/WI-37859 - typehint required until PhpStorm recognises === check
          */
@@ -181,8 +182,8 @@ abstract class Controller extends BaseController implements ControllerInterface
         RequestInterface $request,
         ?string $notFoundException = null
     ): FormattedApiResponseInterface {
-        /** @var \EoneoPay\Externals\ORM\Interfaces\EntityInterface $entity */
         $entity = $this->retrieveEntity($entityClass, $entityId, $notFoundException);
+
         $entity->fill($request->toArray());
 
         $this->saveEntity($entity);

--- a/src/Interfaces/ControllerInterface.php
+++ b/src/Interfaces/ControllerInterface.php
@@ -5,6 +5,7 @@ namespace EoneoPay\Framework\Interfaces;
 
 use EoneoPay\ApiFormats\Interfaces\FormattedApiResponseInterface;
 use EoneoPay\Externals\ORM\Interfaces\EntityInterface;
+use EoneoPay\Externals\ORM\Interfaces\MagicEntityInterface;
 use EoneoPay\Externals\Request\Interfaces\RequestInterface;
 
 interface ControllerInterface
@@ -70,7 +71,7 @@ interface ControllerInterface
      * @param string $entityId
      * @param null|string $notFoundException
      *
-     * @return \EoneoPay\Externals\ORM\Interfaces\EntityInterface
+     * @return \EoneoPay\Externals\ORM\Interfaces\MagicEntityInterface
      *
      * @throws \EoneoPay\Utils\Exceptions\NotFoundException
      */
@@ -78,7 +79,7 @@ interface ControllerInterface
         string $entityClass,
         string $entityId,
         ?string $notFoundException = null
-    ): EntityInterface;
+    ): MagicEntityInterface;
 
     /**
      * Save entity into database.


### PR DESCRIPTION
This makes a simple adjustment to the framework package to account for the removal of `fill` from EntityInterface.

These methods are not used in any current projects.